### PR TITLE
go_router を用いたルーティング実装、及びエラーページ実装

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import '/screens/home_screen.dart';
+import '/utils/routes.dart';
 
 void main() {
   runApp(const MyApp());
@@ -10,12 +10,11 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-      ),
-      home: const HomeScreen(title: 'Flutter Demo Home Page'),
+    return MaterialApp.router(
+      routeInformationProvider: router.routeInformationProvider,
+      routeInformationParser: router.routeInformationParser,
+      routerDelegate: router.routerDelegate,
+      title: 'Ryukalice',
     );
   }
 }

--- a/lib/screens/error_screen.dart
+++ b/lib/screens/error_screen.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class ErrorScreen extends StatelessWidget {
+  final String error;
+  const ErrorScreen({Key? key, required this.error}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('エラー')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text('ページが見つかりませんでした'),
+            ElevatedButton(
+              onPressed: () => context.go('/'),
+              child: const Text('トップページ'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/error_screen.dart
+++ b/lib/screens/error_screen.dart
@@ -13,7 +13,7 @@ class ErrorScreen extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            const Text('ページが見つかりませんでした'),
+            Text(error),
             ElevatedButton(
               onPressed: () => context.go('/'),
               child: const Text('トップページ'),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({Key? key}) : super(key: key);
@@ -15,7 +16,12 @@ class _State extends State<HomeScreen> {
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
-          children: const <Widget>[],
+          children: <Widget>[
+            ElevatedButton(
+              onPressed: () => context.go('/error'),
+              child: const Text('エラーページ'),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,47 +1,22 @@
 import 'package:flutter/material.dart';
 
 class HomeScreen extends StatefulWidget {
-  const HomeScreen({Key? key, required this.title}) : super(key: key);
-
-  final String title;
+  const HomeScreen({Key? key}) : super(key: key);
 
   @override
   State<HomeScreen> createState() => _State();
 }
 
 class _State extends State<HomeScreen> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.title),
-      ),
+      appBar: AppBar(title: const Text('トップページ')),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headline4,
-            ),
-          ],
+          children: const <Widget>[],
         ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
       ),
     );
   }

--- a/lib/utils/routes.dart
+++ b/lib/utils/routes.dart
@@ -1,0 +1,9 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '/screens/home_screen.dart';
+
+final GoRouter router = GoRouter(
+  routes: <GoRoute>[
+    GoRoute(path: '/', builder: (BuildContext context, GoRouterState state) => const HomeScreen()),
+  ],
+);

--- a/lib/utils/routes.dart
+++ b/lib/utils/routes.dart
@@ -1,9 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import '/screens/home_screen.dart';
+import '/screens/error_screen.dart';
 
 final GoRouter router = GoRouter(
   routes: <GoRoute>[
     GoRoute(path: '/', builder: (BuildContext context, GoRouterState state) => const HomeScreen()),
   ],
+  errorPageBuilder: (context, state) => MaterialPage<void>(
+    child: ErrorScreen(error: state.error.toString()),
+  ),
 );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -74,6 +74,25 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.7"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.4"
   lints:
     dependency: transitive
     description:
@@ -81,6 +100,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  logging:
+    dependency: transitive
+    description:
+      name: logging
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.2"
   matcher:
     dependency: transitive
     description:
@@ -165,3 +191,4 @@ packages:
     version: "2.1.2"
 sdks:
   dart: ">=2.17.6 <3.0.0"
+  flutter: ">=3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  go_router: ^4.2.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
URL 直打ちでの画面遷移がまだできないため、トップページにエラーページ内容確認のための、存在しないリンクへの遷移ボタンを仮配置しています。